### PR TITLE
feature: automatic deploy

### DIFF
--- a/src/main/java/com/prestek/agent/config/OpenApiConfig.java
+++ b/src/main/java/com/prestek/agent/config/OpenApiConfig.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.models.servers.Server;
 @Configuration
 public class OpenApiConfig {
 
-    @Value("${server.port:8081}")
+    @Value("${server.port}")
     private String serverPort;
 
     @Bean


### PR DESCRIPTION
This pull request makes a minor update to the `OpenApiConfig` configuration. The default value for `server.port` has been removed, so the application will now require this value to be explicitly set in the configuration.

- Removed the default value (`8081`) from the `@Value` annotation for `server.port` in `OpenApiConfig.java`, making the port configuration mandatory.